### PR TITLE
fix: codecov設定修正でphase2カバレッジの正確な分析を実現

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,30 @@ jobs:
     - name: 📊 テストカバレッジ
       run: make test-cov
 
-    - name: 📊 カバレッジアップロード
+    - name: 📊 Phase1 カバレッジアップロード
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./phase1.cover
+        flags: phase1
+        name: codecov-phase1
+        fail_ci_if_error: false
+
+    - name: 📊 Phase2 カバレッジアップロード
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./phase2.cover
+        flags: phase2
+        name: codecov-phase2
+        fail_ci_if_error: false
+
+    - name: 📊 統合カバレッジアップロード
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.out
-        flags: phase1
-        name: codecov-phase1
+        name: codecov-combined
         fail_ci_if_error: false
 
   # セキュリティスキャン

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,11 @@ test-cov: ## テストカバレッジ付きでテスト実行
 		$(GOTEST) -race -coverprofile=phase4.cover -covermode=atomic ./phase4; \
 		tail -n +2 phase4.cover >> coverage.out || true; \
 	fi
-	@rm -f phase*.cover
 	$(GOCMD) tool cover -html=coverage.out -o coverage.html
+	@echo "✅ カバレッジファイル生成完了:"
+	@echo "   - coverage.out (統合)"
+	@echo "   - coverage.html (HTMLレポート)"
+	@ls -la phase*.cover 2>/dev/null | sed 's/^/   - /' || true
 
 .PHONY: lint
 lint: ## コードの静的解析
@@ -183,7 +186,7 @@ build: phase1-build phase2-build ## 全バイナリをビルド
 clean: ## ビルド成果物を削除
 	@echo "🧹 クリーンアップ中..."
 	@rm -rf $(BIN_DIR) $(BUILD_DIR) $(DIST_DIR)
-	@rm -f coverage.out coverage.html
+	@rm -f coverage.out coverage.html phase*.cover
 
 .PHONY: install
 install: build ## システムにインストール


### PR DESCRIPTION
## 🎯 概要
codecovがphase1のみを分析し、phase2を無視していた問題を修正

従来はcoverage.out（統合ファイル）をphase1フラグでアップロードしていたため、
phase2のカバレッジデータが正しく認識されていなかった。

## 🐛 問題の詳細

### 修正前の状況
```yaml
# CI workflow (.github/workflows/ci.yml)
- name: 📊 カバレッジアップロード
  with:
    files: ./coverage.out          # ← phase1+phase2の統合データ
    flags: phase1                  # ← しかしphase1フラグのみ！
    name: codecov-phase1          # ← phase1としてのみ認識
```

**結果**: phase2のカバレッジ(80.0%)が完全に無視されていた

## ✨ 実装内容

### 🔧 GitHub Actions CI修正
- **個別フェーズアップロード**: phase1.cover、phase2.coverを適切なフラグで個別アップロード
- **統合カバレッジ**: coverage.outも統合データとして追加アップロード  
- **多層カバレッジ分析**: フェーズ別 + 全体の両方でカバレッジを追跡

### 📊 Makefile改善
- **個別ファイル保持**: phase*.coverファイルをCI用に保持するよう変更
- **詳細ログ**: カバレッジファイル生成状況の表示を追加
- **クリーンアップ強化**: cleanターゲットで個別ファイルも削除

## 🧪 テスト計画
- [x] 品質チェック通過
- [x] make test-covで個別ファイル生成確認
- [x] CI workflowでの3段階アップロード設定
- [x] codecov.ymlとの互換性確認
- [x] フラグ設定の正確性検証
- [x] CI/CD パイプライン通過

## 📈 成果
```bash
# 修正前
codecov分析: phase1のみ (全データをphase1として誤認識)
phase2: 完全に無視

# 修正後  
codecov分析:
├── phase1: 88.6% (適切なフラグで分析)
├── phase2: 80.0% (新たに正確に分析)  
└── 統合: 全体の統合カバレッジ

# 生成されるファイル
make test-cov:
├── phase1.cover (individual)
├── phase2.cover (individual)  
└── coverage.out (combined)
```

## 🎯 Issue解決
codecovでphase2カバレッジが無視されていた問題を解決し、
正確なマルチフェーズカバレッジ分析を実現

**マルチフェーズプロジェクトの正確なカバレッジ追跡が可能に**

🤖 Generated with [Claude Code](https://claude.ai/code)