### PR TITLE
fix: gosec G703 path traversal suppressions

### DIFF
--- a/cmd/compiler/main.go
+++ b/cmd/compiler/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	// ソースファイルを読み込み
-	// #nosec G304 -- inputFile is validated above to prevent path traversal
+	// #nosec G304 G703 -- inputFile is validated above to prevent path traversal
 	source, err := os.ReadFile(inputFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "エラー: ファイル読み込み失敗: %v\n", err)
@@ -77,7 +77,7 @@ func main() {
 
 	// アセンブリコードをファイルに出力
 	fmt.Println("💾 アセンブリファイル出力中...")
-	err = os.WriteFile(outputFile, []byte(asmCode), 0600)
+	err = os.WriteFile(outputFile, []byte(asmCode), 0600) // #nosec G703 -- outputFile is derived from validated inputFile
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ ファイル出力エラー: %v\n", err)
 		os.Exit(1)

--- a/cmd/interp/main.go
+++ b/cmd/interp/main.go
@@ -88,7 +88,7 @@ func executeFile(filename string) error {
 	}
 
 	// ファイルを読み込む
-	// #nosec G304 - ファイルパスは上記のvalidateFilePathで検証済み
+	// #nosec G304 G703 - ファイルパスは上記のvalidateFilePathで検証済み
 	input, err := os.ReadFile(filename)
 	if err != nil {
 		return fmt.Errorf("ファイルの読み込みに失敗しました: %v", err)

--- a/cmd/pug/main.go
+++ b/cmd/pug/main.go
@@ -25,7 +25,7 @@ func main() {
 	fmt.Printf("📄 ファイル '%s' をコンパイル中...\n", filename)
 
 	// ファイルを読み込み
-	// #nosec G304 - コンパイラツールとしてファイル読み込みは必要な機能
+	// #nosec G304 G703 - コンパイラツールとしてファイル読み込みは必要な機能
 	input, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Printf("❌ ファイル読み込みエラー: %v\n", err)


### PR DESCRIPTION
## Summary
- Add `G703` to existing `#nosec G304` comments in `cmd/pug/main.go`, `cmd/interp/main.go`, and `cmd/compiler/main.go` (ReadFile calls)
- Add `#nosec G703` comment to `os.WriteFile` call in `cmd/compiler/main.go` (line 80)

## Rationale
gosec G703 (path traversal via taint analysis) is triggering on file I/O operations that use user-supplied paths. These are compiler/interpreter CLI tools where reading source files and writing output files from command-line arguments is the core intended functionality. Path validation (e.g., `..` checks, working directory prefix checks) is already in place where applicable.

This fix unblocks Dependabot PRs #61 and #62 which are currently failing CI due to these gosec findings.

## Test plan
- [ ] Verify CI passes with gosec checks
- [ ] Confirm Dependabot PRs #61 and #62 can be re-run and merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)